### PR TITLE
Fixe the bug `[RCTRootView cancelTouches]`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,8 @@
 /**
  * @format
  */
-import 'react-native-gesture-handler';
-import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
-import { AppRegistry, YellowBox } from 'react-native';
+import { AppRegistry } from 'react-native';
 import App from './src/App';
 import { name as appName } from './app.json';
 
-YellowBox.ignoreWarnings([
-  'RCTRootView cancelTouches', // https://github.com/kmagiera/react-native-gesture-handler/issues/746
-  'Warning: DatePickerAndroid', // will be fixed with https://github.com/mmazzarolo/react-native-modal-datetime-picker/pull/262
-  'Warning: DatePickerIOS' // will be fixed with https://github.com/mmazzarolo/react-native-modal-datetime-picker/pull/262
-]);
-
-AppRegistry.registerComponent(appName, () => gestureHandlerRootHOC(App));
+AppRegistry.registerComponent(appName, () => App);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.61.2",
     "react-native-button": "^2.4.0",
     "react-native-check-box": "^2.1.7",
-    "react-native-gesture-handler": "^1.4.1",
+    "react-native-gesture-handler": "^1.5.0",
     "react-native-modal": "^11.4.0",
     "react-native-modal-datetime-picker": "^7.6.0",
     "react-native-picker-select": "^6.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5859,10 +5859,10 @@ react-native-check-box@^2.1.7:
   dependencies:
     prop-types "^15.5.7"
 
-react-native-gesture-handler@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz#c38d9e57637b95e221722a79f2bafac62e3aeb21"
-  integrity sha512-Ffcs+SbEbkGaal0CClYL+v7A9y4OA5G5lW01qrzjxaqASp5C8BfnWSKuqYKE00s6bLwE5L4xnlHkG0yIxAtbrQ==
+react-native-gesture-handler@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.0.tgz#df7dc5285c152e0656db70f55200fa632c4f45af"
+  integrity sha512-YUOXHsGLajK1cFReQ4Xh0H9GUTxDW9cUZEVu1q+dVqur2urSKi63KklAFB2l8Neob9nl1E/w0c5hGcBP9FMCIA==
   dependencies:
     hammerjs "^2.0.8"
     hoist-non-react-statics "^2.3.1"


### PR DESCRIPTION
This bug appeared in the version of ``"react-native-gesture-handler": "^1.4.1" ``.  All this happened because Facebook will make [some internal changes](https://github.com/facebook/react-native/commit/36307d87e1974aff1abac598da2fd11c4e8e23c1) in react-native.  To solve this bug, just update the pack to its latest version 😸 

more info here: https://github.com/kmagiera/react-native-gesture-handler/issues/746